### PR TITLE
add comment

### DIFF
--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -623,7 +623,9 @@ NgChm.UTIL.loadANACHM = function (sizeBuilderView) {
 	const queryString = location.search;
 	const urlParams = new URLSearchParams(queryString);
 	const blobUri = urlParams.get('bloburi')
-	if (!blobUri) {
+	const delim = "&sig=";
+
+	if (!blobUri || !blobUri.includes(delim)) {
 		return;
 	}
 
@@ -631,7 +633,6 @@ NgChm.UTIL.loadANACHM = function (sizeBuilderView) {
 	// As such, it is URL-encoded. So, we first unescape to get the full URI.
 	// However, a part of this URI is the SAS for AzureBlob which needs to be encoded, so re-encode that part.
 	// In particular, the SAS contains plus signs that don't consistently get escaped/unescaped. The below code should be consistent.
-	const delim = "&sig=";
 	var unescapedParts = unescape(blobUri).split(delim);
 	var properlyFormed = unescapedParts[0] + delim + encodeURIComponent(unescapedParts[1]);
 

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -626,7 +626,16 @@ NgChm.UTIL.loadANACHM = function (sizeBuilderView) {
 	if (!blobUri) {
 		return;
 	}
-	xhr.open('GET', unescape(blobUri))
+
+	// This URI was taken from a query param, but also contains query params of its own.
+	// As such, it is URL-encoded. So, we first unescape to get the full URI.
+	// However, a part of this URI is the SAS for AzureBlob which needs to be encoded, so re-encode that part.
+	// In particular, the SAS contains plus signs that don't consistently get escaped/unescaped. The below code should be consistent.
+	const delim = "&sig=";
+	var unescapedParts = unescape(blobUri).split(delim);
+	var properlyFormed = unescapedParts[0] + delim + encodeURIComponent(unescapedParts[1]);
+
+	xhr.open('GET', properlyFormed)
 	xhr.setRequestHeader('Access-Control-Allow-Origin', '*');
 	xhr.responseType = 'blob';
 	xhr.onload = function(e) {


### PR DESCRIPTION
// The URI we show is taken from a query param, but also contains query params of its own.
// As such, it is URL-encoded. So, we first unescape to get the full URI.
// However, a part of this URI is the SAS for AzureBlob which needs to be encoded, so re-encode that part.
// In particular, the SAS contains plus signs that don't consistently get escaped/unescaped. This PR should fix that to be consistent.